### PR TITLE
Add basic hello world API route as an example

### DIFF
--- a/Back-End/api/hello.py
+++ b/Back-End/api/hello.py
@@ -1,0 +1,9 @@
+from rest_framework.decorators import api_view
+from rest_framework.response import Response
+from rest_framework.reverse import reverse
+ 
+@api_view(['GET'])
+def hello_world(request, format=None):
+    return Response({
+       'message': 'hello world!'
+    })

--- a/Back-End/api/urls.py
+++ b/Back-End/api/urls.py
@@ -15,7 +15,9 @@ Including another URLconf
 """
 from django.conf.urls import url
 from django.contrib import admin
+from api import hello
 
 urlpatterns = [
     url(r'^admin/', admin.site.urls),
+    url(r'^hello/', hello.hello_world)
 ]


### PR DESCRIPTION
Issue ref: #9 

We probably shouldn't merge this into develop as its main purpose is just to see how to set up a basic HTTP endpoint in django rest framework. I doubt we'd actually have a hello world endpoint in the actual application 😛 